### PR TITLE
Mac OS X to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mac OS X Keylogger
+# macOS Keylogger
 
-This repository holds the code for a simple and easy to use keylogger for Mac OS X. It is not meant to be malicious, and is written as a proof of concept. There is not a lot of information on keyloggers or implementing them on Mac OS X, and most of the ones I've seen do not work as indicated. This project aims to be a simple implementation on how it can be accomplished on OS X.
+This repository holds the code for a simple and easy to use keylogger for macOS. It is not meant to be malicious, and is written as a proof of concept. There is not a lot of information on keyloggers or implementing them on macOS, and most of the ones I've seen do not work as indicated. This project aims to be a simple implementation on how it can be accomplished on OS X.
 
 > Note: This keylogger is currently unable to capture secure input such as passwords. See issue #3 for more information.
 


### PR DESCRIPTION
This is a very minor nit. Apple changed their OS name from Mac OS X to macOS. Humbly proposing to change it in the README.md documentation. Good tool!